### PR TITLE
fix: remove old url sitemap that already change id -> slug name

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -10,14 +10,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     return `${baseUrl}/surah/${getSurahSlugById(nomor)}`;
   });
 
-  // Keep the old Urls by number "/surah/1"
-  // This to let google crawl new redirect urls
-  // NOTE: will remove this after fully redirect to new url, estimate 6 - 12 months
-  const surahUrlsOld = Array.from({ length: TOTAL_SURAH }, (_, i) => {
-    const nomor = i + 1;
-    return `${baseUrl}/surah/${nomor}`;
-  });
-
   const staticUrls = [
     `${baseUrl}`,
     `${baseUrl}/jadwal-sholat`,
@@ -26,7 +18,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     `${baseUrl}/tasbih-digital`,
   ];
 
-  const allUrls = [...staticUrls, ...surahUrls, ...surahUrlsOld];
+  const allUrls = [...staticUrls, ...surahUrls];
   const results: MetadataRoute.Sitemap = allUrls.map((url) => ({
     url,
     lastModified: new Date(),


### PR DESCRIPTION
<img width="920" height="649" alt="Screenshot 2025-11-02 at 21 09 52" src="https://github.com/user-attachments/assets/3a1f4e61-ea74-4795-98bb-1040885ed845" />

context issue:
* regarding duplicate canonical page SEO
* duplicate content/identically html on 2 url's